### PR TITLE
feat(export): PDF report generator and export ViewModel (Issue #10)

### DIFF
--- a/app/src/androidTest/java/com/metalinspect/app/PdfExportUiTest.kt
+++ b/app/src/androidTest/java/com/metalinspect/app/PdfExportUiTest.kt
@@ -1,0 +1,52 @@
+package com.metalinspect.app
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.metalinspect.app.data.pdf.PdfReportGenerator
+import com.metalinspect.app.domain.model.Defect
+import com.metalinspect.app.domain.model.Inspection
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.util.Date
+
+@RunWith(AndroidJUnit4::class)
+class PdfExportUiTest {
+
+    @get:Rule
+    val activityRule = ActivityScenarioRule(androidx.activity.ComponentActivity::class.java)
+
+    @Test
+    fun generatePdf_and_saveToCache_succeeds_under10MB() {
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        val cacheFile = File(ctx.cacheDir, "test_export.pdf")
+        cacheFile.outputStream().use { out ->
+            val generator = PdfReportGenerator()
+            val inspection = Inspection(
+                id = "t1",
+                vesselName = "Vessel",
+                cargoDescription = "Steel coils",
+                inspectionDate = Date(),
+                inspectorName = "Tester",
+                location = "Port",
+                weatherConditions = "Clear",
+                cargoQuantity = 1000.0,
+                cargoUnit = "MT",
+                inspectionType = "loading",
+                qualityGrade = null,
+                moistureContent = null,
+                contaminationLevel = null,
+                overallCondition = "Good",
+                notes = "Sample"
+            )
+            val defects = listOf<Defect>()
+            generator.generate(out, inspection, defects, emptyList())
+        }
+        assertTrue(cacheFile.exists())
+        assertTrue("PDF should be < 10MB", cacheFile.length() < 10L * 1024 * 1024)
+        cacheFile.delete()
+    }
+}

--- a/app/src/main/java/com/metalinspect/app/data/pdf/PdfReportGenerator.kt
+++ b/app/src/main/java/com/metalinspect/app/data/pdf/PdfReportGenerator.kt
@@ -1,0 +1,104 @@
+package com.metalinspect.app.data.pdf
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import com.itextpdf.kernel.colors.ColorConstants
+import com.itextpdf.kernel.font.PdfFontFactory
+import com.itextpdf.kernel.geom.PageSize
+import com.itextpdf.kernel.pdf.PdfWriter
+import com.itextpdf.kernel.pdf.PdfDocument
+import com.itextpdf.layout.Document
+import com.itextpdf.layout.borders.SolidBorder
+import com.itextpdf.layout.element.Cell
+import com.itextpdf.layout.element.Paragraph
+import com.itextpdf.layout.element.Table
+import com.itextpdf.layout.property.TextAlignment
+import com.metalinspect.app.domain.model.Defect
+import com.metalinspect.app.domain.model.Inspection
+import java.io.OutputStream
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+/**
+ * Service that generates a PDF report for a given inspection
+ */
+class PdfReportGenerator(
+    private val context: Context
+) {
+    private val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.US)
+
+    fun generate(
+        output: OutputStream,
+        inspection: Inspection,
+        defects: List<Defect>,
+        photos: List<Bitmap> = emptyList()
+    ) {
+        val writer = PdfWriter(output)
+        val pdf = PdfDocument(writer)
+        val doc = Document(pdf, PageSize.A4)
+        val font = PdfFontFactory.createFont()
+        doc.setFont(font)
+
+        // Title
+        doc.add(
+            Paragraph("Inspection Report")
+                .setBold()
+                .setFontSize(18f)
+                .setTextAlignment(TextAlignment.CENTER)
+        )
+
+        // Header table
+        val header = Table(floatArrayOf(1f, 2f)).useAllAvailableWidth()
+        header.addCell(headerCell("Vessel"))
+        header.addCell(valueCell(inspection.vesselName))
+        header.addCell(headerCell("Date"))
+        header.addCell(valueCell(dateFormat.format(inspection.inspectionDate)))
+        header.addCell(headerCell("Inspector"))
+        header.addCell(valueCell(inspection.inspectorName))
+        header.addCell(headerCell("Location"))
+        header.addCell(valueCell(inspection.location))
+        header.addCell(headerCell("Cargo"))
+        header.addCell(valueCell("${inspection.cargoDescription} (${inspection.cargoQuantity} ${inspection.cargoUnit})"))
+        doc.add(header)
+
+        doc.add(Paragraph("\n"))
+
+        // Defects table
+        val defectTable = Table(floatArrayOf(1.2f, 0.8f, 3f, 1f)).useAllAvailableWidth()
+        listOf("Type", "Severity", "Description", "%/Qty").forEach { defectTable.addHeaderCell(headerCell(it)) }
+        defects.forEach { d ->
+            defectTable.addCell(valueCell(d.defectType))
+            defectTable.addCell(valueCell(d.severity))
+            defectTable.addCell(valueCell(d.description))
+            val pct = d.estimatedAffectedPercentage?.let { String.format(Locale.US, "%.1f%%", it) } ?: "-"
+            val qty = d.estimatedAffectedQuantity?.let { String.format(Locale.US, "%.1f", it) } ?: "-"
+            defectTable.addCell(valueCell("$pct / $qty"))
+        }
+        doc.add(Paragraph("Defects").setBold().setFontSize(14f))
+        doc.add(defectTable)
+
+        // Summary
+        val criticalCount = defects.count { it.isCritical }
+        val summary = Table(floatArrayOf(1f, 1f, 1f)).useAllAvailableWidth()
+        summary.addCell(headerCell("Total Defects"))
+        summary.addCell(headerCell("Critical"))
+        summary.addCell(headerCell("Completed"))
+        summary.addCell(valueCell(defects.size.toString()))
+        summary.addCell(valueCell(criticalCount.toString()))
+        summary.addCell(valueCell(if (inspection.isCompleted) "Yes" else "No"))
+        doc.add(Paragraph("Summary").setBold().setFontSize(14f))
+        doc.add(summary)
+
+        doc.add(Paragraph("\nNotes:")).add(Paragraph(inspection.notes ?: "-")
+            .setBorder(SolidBorder(ColorConstants.LIGHT_GRAY, 0.5f)))
+
+        doc.close()
+    }
+
+    private fun headerCell(text: String): Cell =
+        Cell().add(Paragraph(text).setBold()).setBackgroundColor(ColorConstants.LIGHT_GRAY)
+
+    private fun valueCell(text: String): Cell =
+        Cell().add(Paragraph(text))
+}

--- a/app/src/main/java/com/metalinspect/app/presentation/viewmodel/PdfExportViewModel.kt
+++ b/app/src/main/java/com/metalinspect/app/presentation/viewmodel/PdfExportViewModel.kt
@@ -1,0 +1,55 @@
+package com.metalinspect.app.presentation.viewmodel
+
+import android.content.ContentResolver
+import android.content.ContentValues
+import android.provider.MediaStore
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.metalinspect.app.domain.model.Defect
+import com.metalinspect.app.domain.model.Inspection
+import com.metalinspect.app.domain.usecase.GetInspectionsUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Locale
+import javax.inject.Inject
+
+@HiltViewModel
+class PdfExportViewModel @Inject constructor(
+    private val contentResolver: ContentResolver
+) : ViewModel() {
+
+    private val _exportState = MutableStateFlow<ExportState>(ExportState.Idle)
+    val exportState: StateFlow<ExportState> = _exportState
+
+    fun export(
+        fileName: String,
+        write: (out: java.io.OutputStream) -> Unit
+    ) {
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                _exportState.value = ExportState.Running
+                val values = ContentValues().apply {
+                    put(MediaStore.Downloads.DISPLAY_NAME, fileName)
+                    put(MediaStore.Downloads.MIME_TYPE, "application/pdf")
+                }
+                val uri = contentResolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values)
+                    ?: throw IllegalStateException("Cannot create file")
+                contentResolver.openOutputStream(uri)?.use { out -> write(out) }
+                _exportState.value = ExportState.Success(uri = uri.toString())
+            } catch (e: Exception) {
+                _exportState.value = ExportState.Error(e.message ?: "Unknown error")
+            }
+        }
+    }
+}
+
+sealed class ExportState {
+    object Idle : ExportState()
+    object Running : ExportState()
+    data class Success(val uri: String) : ExportState()
+    data class Error(val message: String) : ExportState()
+}


### PR DESCRIPTION
Implements PDF export per Issue #10.

- PdfReportGenerator with header, defects table, summary and notes
- PdfExportViewModel to write to MediaStore Downloads with state feedback
- Designed for integration from Inspection Detail screen (Export PDF button)

Follow ups:
- Embed photos with compression
- Hook UI tests for export
- Add unit/instrumented tests for generator and file naming